### PR TITLE
Partial PR: Adding models for expense-related data and merging branch-push-fix changes

### DIFF
--- a/src/Logic/Logic.Models/DataModels/Expense.cs
+++ b/src/Logic/Logic.Models/DataModels/Expense.cs
@@ -1,0 +1,112 @@
+namespace devdeer.CoffeeCupApiAccess.Logic.Models.DataModels
+{
+    using System;
+    using System.Linq;
+    using System.Text.Json.Serialization;
+
+    /// <summary>
+    /// Contains the information about a single expense in CoffeeCup.
+    /// </summary>
+    public class Expense
+    {
+        #region properties
+
+        /// <summary>
+        /// The timestamp when the expense was updated last.
+        /// </summary>
+        [JsonPropertyName("createdAt")]
+        public DateTime CreatedAt { get; set; }
+
+        /// <summary>
+        /// The timestamp when the expense was updated last.
+        /// </summary>
+        [JsonPropertyName("updatedAt")]
+        public DateTime UpdatedAt { get; set; }
+
+        /// <summary>
+        /// The unique identifier of the expense.
+        /// </summary>
+        [JsonPropertyName("id")]
+        public int Id { get; set; }
+
+        /// <summary>
+        /// The description of the expense.
+        /// </summary>
+        [JsonPropertyName("description")]
+        public string? Description { get; set; }
+
+        /// <summary>
+        /// The quantity of the expense.
+        /// </summary>
+        [JsonPropertyName("quantity")]
+        public int? Quantity { get; set; }
+
+        /// <summary>
+        /// The internal price of the expense.
+        /// </summary>
+        [JsonPropertyName("priceInternal")]
+        public double? PriceInternal { get; set; }
+
+        /// <summary>
+        /// The external price of the expense.
+        /// </summary>
+        [JsonPropertyName("priceExternal")]
+        public double? PriceExternal { get; set; }
+
+        /// <summary>
+        /// Indicates whether the expense is billable.
+        /// </summary>
+        [JsonPropertyName("isBillable")]
+        public bool IsBillable { get; set; }
+
+        /// <summary>
+        /// Indicates whether the expense is in budget.
+        /// </summary>
+        [JsonPropertyName("inBudget")]
+        public bool InBudget { get; set; }
+
+        /// <summary>
+        /// Indicates whether the expense is recurring.
+        /// </summary>
+        [JsonPropertyName("isRecurring")]
+        public bool IsRecurring { get; set; }
+
+        /// <summary>
+        /// The timestamp when the expense was billed.
+        /// </summary>
+        [JsonPropertyName("billedAt")]
+        public DateTime BilledAt { get; set; }
+
+        /// <summary>
+        /// The day of the expense.
+        /// </summary>
+        [JsonPropertyName("day")]
+        public DateOnly Day { get; set; }
+
+        /// <summary>
+        /// The percentage associated with the expense.
+        /// </summary>
+        [JsonPropertyName("percent")]
+        public double? Percent { get; set; }
+
+        /// <summary>
+        /// The project ID of the expense.
+        /// </summary>
+        [JsonPropertyName("project")]
+        public long ProjectId { get; set; }
+
+        /// <summary>
+        /// The expense category ID of the expense.
+        /// </summary>
+        [JsonPropertyName("expenseCategory")]
+        public int ExpenseCategoryId { get; set; }
+
+        /// <summary>
+        /// The invoice ID of the expense.
+        /// </summary>
+        [JsonPropertyName("invoice")]
+        public int? InvoiceId { get; set; }
+
+        #endregion
+    }
+}

--- a/src/Logic/Logic.Models/DataModels/ExpenseCategory.cs
+++ b/src/Logic/Logic.Models/DataModels/ExpenseCategory.cs
@@ -1,0 +1,99 @@
+namespace devdeer.CoffeeCupApiAccess.Logic.Models.DataModels
+{
+    using System;
+    using System.Linq;
+    using System.Text.Json.Serialization;
+
+    using Enumerations;
+
+    /// <summary>
+    /// Contains the information about a single expense category in CoffeeCup.
+    /// </summary>
+    public class ExpenseCategory
+    {
+        #region properties
+
+        /// <summary>
+        /// The timestamp when the expense category was created.
+        /// </summary>
+        [JsonPropertyName("createdAt")]
+        public DateTime CreatedAt { get; set; }
+
+        /// <summary>
+        /// The timestamp when the expense category was updated last.
+        /// </summary>
+        [JsonPropertyName("updatedAt")]
+        public DateTime UpdatedAt { get; set; }
+
+        /// <summary>
+        /// The unique identifier of the expense category.
+        /// </summary>
+        [JsonPropertyName("id")]
+        public int Id { get; set; }
+
+        /// <summary>
+        /// The label of the expense category.
+        /// </summary>
+        [JsonPropertyName("label")]
+        public string Label { get; set; } = default!;
+
+        /// <summary>
+        /// The type of the expense category.
+        /// </summary>
+        [JsonPropertyName("type")]
+        public ExpenseCategoryType Type { get; set; }
+
+        /// <summary>
+        /// The unit of the expense category.
+        /// </summary>
+        [JsonPropertyName("unit")]
+        public string? Unit { get; set; }
+
+        /// <summary>
+        /// The icon of the expense category.
+        /// </summary>
+        [JsonPropertyName("icon")]
+        public int Icon { get; set; }
+
+        [JsonPropertyName("pricePerUnit")]
+        public double? PricePerUnit { get; set; }
+
+        /// <summary>
+        /// The color of the expense category.
+        /// </summary>
+        [JsonPropertyName("color")]
+        public int Color { get; set; }
+
+        /// <summary>
+        /// Indicates the expense category's status.
+        /// </summary>
+        [JsonPropertyName("status")]
+        public bool Status { get; set; }
+
+        /// <summary>
+        /// The billing ID of the expense category.
+        /// </summary>
+        [JsonPropertyName("billingId")]
+        public string? BillingId { get; set; }
+
+        /// <summary>
+        /// The billing mapping of the expense category.
+        /// </summary>
+        [JsonPropertyName("billingMapping")]
+        public BillingMapping BillingMapping { get; set; }
+
+        /// <summary>
+        /// Indicates whether the value of the expense category can be edited.
+        /// </summary>
+        [JsonPropertyName("allowEditingValue")]
+        public bool AllowEditingValue { get; set; }
+
+        /// <summary>
+        /// The percentage associated with the expense category.
+        /// </summary>
+        [JsonPropertyName("percent")]
+        public double? Percent { get; set; }
+
+        #endregion
+    }
+}

--- a/src/Logic/Logic.Models/Enumerations/BillingMapping.cs
+++ b/src/Logic/Logic.Models/Enumerations/BillingMapping.cs
@@ -1,0 +1,22 @@
+namespace devdeer.CoffeeCupApiAccess.Logic.Models.Enumerations
+{
+    using System;
+    using System.Linq;
+    using System.Text.Json.Serialization;
+
+    using JsonConverters;
+
+    /// <summary>
+    /// Defines possible values for billing mappings.
+    /// </summary>
+    [JsonConverter(typeof(BillingMappingConverter))]
+    public enum BillingMapping
+    {
+        /// <summary>
+        /// Undefined expense category type, signalazing parsing error.
+        /// </summary>
+        Undefined = 0,
+        Service = 1,
+        Product = 2
+    }
+}

--- a/src/Logic/Logic.Models/Enumerations/BillingMapping.cs
+++ b/src/Logic/Logic.Models/Enumerations/BillingMapping.cs
@@ -13,7 +13,7 @@ namespace devdeer.CoffeeCupApiAccess.Logic.Models.Enumerations
     public enum BillingMapping
     {
         /// <summary>
-        /// Undefined expense category type, signalazing parsing error.
+        /// Undefined billing mapping, signalazing parsing error.
         /// </summary>
         Undefined = 0,
         Service = 1,

--- a/src/Logic/Logic.Models/Enumerations/ExpenseCategoryType.cs
+++ b/src/Logic/Logic.Models/Enumerations/ExpenseCategoryType.cs
@@ -1,0 +1,20 @@
+namespace devdeer.CoffeeCupApiAccess.Logic.Models.Enumerations
+{
+    using System;
+    using System.Linq;
+    using System.Text.Json.Serialization;
+
+    /// <summary>
+    /// Defines possible values for expense categories.
+    /// </summary>
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum ExpenseCategoryType
+    {
+        /// <summary>
+        /// Undefined expense category type, signalazing parsing error.
+        /// </summary>
+        Undefined = 0,
+        Amount = 1,
+        Percent = 2
+    }
+}

--- a/src/Logic/Logic.Models/Enumerations/ExpenseCategoryType.cs
+++ b/src/Logic/Logic.Models/Enumerations/ExpenseCategoryType.cs
@@ -4,10 +4,12 @@ namespace devdeer.CoffeeCupApiAccess.Logic.Models.Enumerations
     using System.Linq;
     using System.Text.Json.Serialization;
 
+    using JsonConverters;
+
     /// <summary>
     /// Defines possible values for expense categories.
     /// </summary>
-    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [JsonConverter(typeof(ExpenseCategoryTypeConverter))]
     public enum ExpenseCategoryType
     {
         /// <summary>

--- a/src/Logic/Logic.Models/JsonConverters/BillingMappingConverter.cs
+++ b/src/Logic/Logic.Models/JsonConverters/BillingMappingConverter.cs
@@ -1,0 +1,44 @@
+namespace devdeer.CoffeeCupApiAccess.Logic.Models.JsonConverters
+{
+    using System;
+    using System.Linq;
+    using System.Text.Json;
+    using System.Text.Json.Serialization;
+
+    using Enumerations;
+
+    /// <summary>
+    /// Custom JSON converter for the <see cref="BillingMapping" /> enum to handle the conversion.
+    /// </summary>
+    public class BillingMappingConverter : JsonConverter<BillingMapping>
+    {
+        #region methods
+
+        public override BillingMapping Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            return value?.ToUpperInvariant() switch
+            {
+                "SERVICE" => BillingMapping.Service,
+                "PRODUCT" => BillingMapping.Product,
+                _ => BillingMapping.Undefined
+            };
+        }
+
+        public override void Write(Utf8JsonWriter writer, BillingMapping value, JsonSerializerOptions options)
+        {
+            var stringValue = value switch
+            {
+                BillingMapping.Service => "SERVICE",
+                BillingMapping.Product => "PRODUCT",
+                _ => throw new InvalidOperationException($"Unexpected value when converting BillingMapping: {value}")
+            };
+            writer.WriteStringValue(stringValue);
+        }
+
+        #endregion
+    }
+}

--- a/src/Logic/Logic.Models/JsonConverters/ExpenseCategoryTypeConverter.cs
+++ b/src/Logic/Logic.Models/JsonConverters/ExpenseCategoryTypeConverter.cs
@@ -1,0 +1,45 @@
+namespace devdeer.CoffeeCupApiAccess.Logic.Models.JsonConverters
+{
+    using System;
+    using System.Linq;
+    using System.Text.Json;
+    using System.Text.Json.Serialization;
+
+    using Enumerations;
+
+    /// <summary>
+    /// Custom JSON converter for the <see cref="ExpenseCategoryType" /> enum to handle the conversion.
+    /// </summary>
+    public class ExpenseCategoryTypeConverter : JsonConverter<ExpenseCategoryType>
+    {
+        #region methods
+
+        public override ExpenseCategoryType Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            return value?.ToUpperInvariant() switch
+            {
+                "AMOUNT" => ExpenseCategoryType.Amount,
+                "PERCENT" => ExpenseCategoryType.Percent,
+                _ => ExpenseCategoryType.Undefined
+            };
+        }
+
+        public override void Write(Utf8JsonWriter writer, ExpenseCategoryType value, JsonSerializerOptions options)
+        {
+            var stringValue = value switch
+            {
+                ExpenseCategoryType.Amount => "AMOUNT",
+                ExpenseCategoryType.Percent => "PERCENT",
+                _ => throw new InvalidOperationException(
+                    $"Unexpected value when converting ExpenseCategoryType: {value}")
+            };
+            writer.WriteStringValue(stringValue);
+        }
+
+        #endregion
+    }
+}

--- a/src/Logic/Logic.Models/Logic.Models.csproj
+++ b/src/Logic/Logic.Models/Logic.Models.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <Import Project="$(MSBuildThisFileDirectory)../../Base.props"/>
     <PropertyGroup>
-        <Version>4.2.0</Version>
+        <Version>4.1.0</Version>
         <RootNamespace>devdeer.CoffeeCupApiAccess.Logic.Models</RootNamespace>
         <AssemblyName>CoffeeCupApiAccess.Logic.Models</AssemblyName>
         <PackageId>devdeer.CoffeeCupModels</PackageId>

--- a/src/Logic/Logic.Models/Logic.Models.csproj
+++ b/src/Logic/Logic.Models/Logic.Models.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <Import Project="$(MSBuildThisFileDirectory)../../Base.props"/>
     <PropertyGroup>
-        <Version>4.1.0</Version>
+        <Version>4.2.0</Version>
         <RootNamespace>devdeer.CoffeeCupApiAccess.Logic.Models</RootNamespace>
         <AssemblyName>CoffeeCupApiAccess.Logic.Models</AssemblyName>
         <PackageId>devdeer.CoffeeCupModels</PackageId>
-        <Title>DEVDEER CoffeeCup API Access Models</Title>
+        <Title>DEVDEER CoffeeCup/Aerion API Access Models</Title>
         <NoWarn>1591</NoWarn>
         <Description>Contains the models necessary for the CoffeeCup/Aerion API Access in NuGet package devdeer.CoffeeCupApiAccess.</Description>
         <Summary>Contains the models necessary for the CoffeeCup/Aerion API Access in NuGet package devdeer.CoffeeCupApiAccess.</Summary>

--- a/src/Logic/Logic.Models/release-notes.txt
+++ b/src/Logic/Logic.Models/release-notes.txt
@@ -2,4 +2,5 @@
 - Support for .NET 10
 - User.TimeEntryBackgroundColor is nullable now.
 - Added State for project model.
+- Added expense category and expense models.
 - Nuget updates


### PR DESCRIPTION
# Why Partial?
After models are updated and deployed to NuGet, methods must be implemented as well.
# Intention
- Add new models to [devdeer.CoffeeCupModels](https://feed.nuget.org/packages/devdeer.CoffeeCupModels)
- Bring changes from branch [branch-push-fix](https://github.com/DEVDEER/CoffeeCupApiAccess/tree/branch-push-fix)
# Details
- Added `Expence` and `ExpenceCategory` classes
- For `ExpenceCategory` were added two enums and their custom JSON converters:
  - Enums: `BillingMapping`, `ExpenceCategoryType`
  - Converters: `BillingMappingConverter`, `ExpenceCategoryTypeConverter`
  The reason for custom converters is to have fallback values in case of unexpected values from the API. If default `JsonStringEnumConverter` were used, that would lead to unhandled exception, while deserealization, which make impossible using package if new parameter's value is presented from the Aerion API.
- Merge with branch [branch-push-fix](https://github.com/DEVDEER/CoffeeCupApiAccess/tree/branch-push-fix)
# Breaking Changes
None.