### PR TITLE
Partial PR: Adding response models for expense-related data and adding unit tests for custom JSON converters

### DIFF
--- a/CoffeeCupApiAccess.slnx
+++ b/CoffeeCupApiAccess.slnx
@@ -12,6 +12,6 @@
   </Folder>
   <Folder Name="/Tests/">
     <Project Path="tests/Tests.Logic.Core/Tests.Logic.Core.csproj" />
-    <Project Path="Tests/Tests.Logic.Models/Tests.Logic.Models.csproj" />
+    <Project Path="tests/Tests.Logic.Models/Tests.Logic.Models.csproj" />
   </Folder>
 </Solution>

--- a/CoffeeCupApiAccess.slnx
+++ b/CoffeeCupApiAccess.slnx
@@ -12,5 +12,6 @@
   </Folder>
   <Folder Name="/Tests/">
     <Project Path="tests/Tests.Logic.Core/Tests.Logic.Core.csproj" />
+    <Project Path="Tests/Tests.Logic.Models/Tests.Logic.Models.csproj" />
   </Folder>
 </Solution>

--- a/Tests/Tests.Logic.Models/CoffeeCupModelsTests.cs
+++ b/Tests/Tests.Logic.Models/CoffeeCupModelsTests.cs
@@ -1,0 +1,76 @@
+﻿namespace Tests.Logic.Models
+{
+    using System.Text.Json;
+
+    using devdeer.CoffeeCupApiAccess.Logic.Models.Enumerations;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Contains end-2-end-tests for the <see cref="CoffeeCupAccess" />.
+    /// </summary>
+    [TestFixture]
+    public class CoffeeCupModelsTests
+    {
+        #region methods
+
+        /// <summary>
+        /// Tests deserialization of <see cref="BillingMapping" /> from JSON using its custom converter.
+        /// </summary>
+        [Test]
+        public async Task DeserealizeBillingMapping()
+        {
+            var testCases = new []
+            {
+                JsonDeserealizationTestCase.MustSucseed("uppercase service", "\"SERVICE\"", BillingMapping.Service),
+                JsonDeserealizationTestCase.MustSucseed("lowercase service", "\"service\"", BillingMapping.Service),
+                JsonDeserealizationTestCase.MustSucseed("uppercase product", "\"PRODUCT\"", BillingMapping.Product),
+                JsonDeserealizationTestCase.MustSucseed("lowercase product", "\"product\"", BillingMapping.Product),
+                // Invalid values should be mapped to undefined
+                JsonDeserealizationTestCase.MustSucseed("invalid string", "\"Invalid\"", BillingMapping.Undefined),
+                JsonDeserealizationTestCase.MustSucseed("number value", "123", BillingMapping.Undefined),
+                JsonDeserealizationTestCase.MustSucseed("empty string", "\"\"", BillingMapping.Undefined)
+            };
+            foreach (var testCase in testCases)
+            {
+                var result = JsonSerializer.Deserialize<BillingMapping>(testCase.JsonContent);
+                Assert.That(
+                    result,
+                    Is.EqualTo(testCase.Expected),
+                    $"Failed to deserialize {testCase.Description}: {testCase.JsonContent}");
+            }
+            await Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Tests deserialization of <see cref="ExpenseCategoryType" /> from JSON using its custom converter.
+        /// </summary>
+        [Test]
+        public async Task DeserealizeExpenseCategoryType()
+        {
+            var testCases = new []
+            {
+                JsonDeserealizationTestCase.MustSucseed("uppercase amount", "\"AMOUNT\"", ExpenseCategoryType.Amount),
+                JsonDeserealizationTestCase.MustSucseed("lowercase amount", "\"amount\"", ExpenseCategoryType.Amount),
+                JsonDeserealizationTestCase.MustSucseed("uppercase percent", "\"PERCENT\"", ExpenseCategoryType.Percent),
+                JsonDeserealizationTestCase.MustSucseed("lowercase percent", "\"percent\"", ExpenseCategoryType.Percent),
+                // Invalid values should be mapped to undefined
+                JsonDeserealizationTestCase.MustSucseed("invalid string", "\"Invalid\"", ExpenseCategoryType.Undefined),
+                JsonDeserealizationTestCase.MustSucseed("number value", "123", ExpenseCategoryType.Undefined),
+                JsonDeserealizationTestCase.MustSucseed("empty string", "\"\"", ExpenseCategoryType.Undefined),
+                JsonDeserealizationTestCase.MustSucseed("null value", "null", ExpenseCategoryType.Undefined),
+            };
+            foreach (var testCase in testCases)
+            {
+                var result = JsonSerializer.Deserialize<ExpenseCategoryType>(testCase.JsonContent);
+                Assert.That(
+                    result,
+                    Is.EqualTo(testCase.Expected),
+                    $"Failed to deserialize {testCase.Description}: {testCase.JsonContent}");
+            }
+            await Task.CompletedTask;
+        }
+
+        #endregion
+    }
+}

--- a/Tests/Tests.Logic.Models/JsonDeserealizationTestCase.cs
+++ b/Tests/Tests.Logic.Models/JsonDeserealizationTestCase.cs
@@ -1,0 +1,98 @@
+namespace Tests.Logic.Models
+{
+    /// <summary>
+    /// Represents a test case for JSON deserialization.
+    /// </summary>
+    public class JsonDeserealizationTestCase
+    {
+        #region constructors and destructors
+
+        /// <summary>
+        /// Private constructor.
+        /// </summary>
+        /// <param name="expected">The expected result of the deserialization.</param>
+        /// <param name="jsonContent">The JSON content to be deserialized.</param>
+        /// <param name="description">A description of the test case.</param>
+        /// <remarks>Use static methods for creating test cases.</remarks>
+        private JsonDeserealizationTestCase(object expected, string jsonContent, string description)
+        {
+            Expected = expected;
+            JsonContent = jsonContent;
+            Description = description;
+        }
+
+        /// <summary>
+        /// Private constructor.
+        /// </summary>
+        /// <param name="jsonContent">The JSON content to be deserialized.</param>
+        /// <param name="description">A description of the test case.</param>
+        /// <param name="exception">Optional exception that should be thrown when deserializing the json content.</param>
+        /// <remarks>Use static methods for creating test cases.</remarks>
+        private JsonDeserealizationTestCase(string jsonContent, string description, Exception? exception = null)
+        {
+            Exception = exception;
+            JsonContent = jsonContent;
+            Description = description;
+        }
+
+        #endregion
+
+        #region methods
+        /// <summary>
+        /// Creates a test case that must fail.
+        /// </summary>
+        /// <param name="description">Description of the test case.</param>
+        /// <param name="jsonContent">JSON content to be deserialized.</param>
+        /// <param name="exception">Optional exception that should be thrown when deserializing the JSON content.</param>
+        /// <returns>Test case instance.</returns>
+        public static JsonDeserealizationTestCase MustFail(
+            string description,
+            string jsonContent,
+            Exception? exception = null)
+        {
+            return new JsonDeserealizationTestCase(jsonContent, description, exception);
+        }
+        /// <summary>
+        /// Creates a test case that must succeed.
+        /// </summary>
+        /// <param name="description">Description of the test case.</param>
+        /// <param name="jsonContent">JSON content to be deserialized.</param>
+        /// <param name="expected">Expected deserialized object.</param>
+        /// <returns>Test case instance.</returns>
+        public static JsonDeserealizationTestCase MustSucseed(string description, string jsonContent, object expected)
+        {
+            return new JsonDeserealizationTestCase(expected, jsonContent, description);
+        }
+
+        #endregion
+
+        #region properties
+
+        /// <summary>
+        /// Indicates whether the deserialization is supposed to fail.
+        /// </summary>
+        public bool SupposedToFail => Expected == null;
+
+        /// <summary>
+        /// The expected result of the deserialization.
+        /// </summary>
+        public object? Expected { get; init; }
+
+        /// <summary>
+        /// The json content to deserialize.
+        /// </summary>
+        public string JsonContent { get; init; }
+
+        /// <summary>
+        /// A description of the test case.
+        /// </summary>
+        public string Description { get; init; }
+
+        /// <summary>
+        /// The exception that should be thrown when deserializing the json content.
+        /// </summary>
+        public Exception? Exception { get; init; }
+
+        #endregion
+    }
+}

--- a/Tests/Tests.Logic.Models/Tests.Logic.Models.csproj
+++ b/Tests/Tests.Logic.Models/Tests.Logic.Models.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+    <ItemGroup>
+      <PackageReference Include="Microsoft.NET.Test.Sdk" />
+      <PackageReference Include="NUnit" />
+    </ItemGroup>
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Logic\Logic.Models\Logic.Models.csproj" />
+    </ItemGroup>
+</Project>

--- a/Tests/Tests.Logic.Models/packages.lock.json
+++ b/Tests/Tests.Logic.Models/packages.lock.json
@@ -1,0 +1,50 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.0.1, )",
+        "resolved": "18.0.1",
+        "contentHash": "WNpu6vI2rA0pXY4r7NKxCN16XRWl5uHu6qjuyVLoDo6oYEggIQefrMjkRuibQHm/NslIUNCcKftvoWAN80MSAg==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.0.1",
+          "Microsoft.TestPlatform.TestHost": "18.0.1"
+        }
+      },
+      "NUnit": {
+        "type": "Direct",
+        "requested": "[4.5.0, )",
+        "resolved": "4.5.0",
+        "contentHash": "3AXYqXoll1CnWA+fNqMQemJO5qofh2r75bdrPyJqjCRCcZpwuCAgUnHxG1wKEbrGjtobrWWbwVrDhYcXcxRkjw=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.0.1",
+        "contentHash": "O+utSr97NAJowIQT/OVp3Lh9QgW/wALVTP4RG1m2AfFP4IyJmJz0ZBmFJUsRQiAPgq6IRC0t8AAzsiPIsaUDEA=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.0.1",
+        "contentHash": "qT/mwMcLF9BieRkzOBPL2qCopl8hQu6A1P7JWAoj/FMu5i9vds/7cjbJ/LLtaiwWevWLAeD5v5wjQJ/l6jvhWQ=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.0.1",
+        "contentHash": "uDJKAEjFTaa2wHdWlfo6ektyoh+WD4/Eesrwb4FpBFKsLGehhACVnwwTI4qD3FrIlIEPlxdXg3SyrYRIcO+RRQ==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.0.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "devdeer.CoffeeCupModels": {
+        "type": "Project"
+      }
+    }
+  }
+}

--- a/src/Logic/Logic.Models/JsonConverters/BillingMappingConverter.cs
+++ b/src/Logic/Logic.Models/JsonConverters/BillingMappingConverter.cs
@@ -19,6 +19,10 @@ namespace devdeer.CoffeeCupApiAccess.Logic.Models.JsonConverters
             Type typeToConvert,
             JsonSerializerOptions options)
         {
+            if (reader.TokenType == JsonTokenType.Number)
+            {
+                return BillingMapping.Undefined;
+            }
             var value = reader.GetString();
             return value?.ToUpperInvariant() switch
             {

--- a/src/Logic/Logic.Models/JsonConverters/BillingMappingConverter.cs
+++ b/src/Logic/Logic.Models/JsonConverters/BillingMappingConverter.cs
@@ -21,6 +21,7 @@ namespace devdeer.CoffeeCupApiAccess.Logic.Models.JsonConverters
         {
             if (reader.TokenType == JsonTokenType.Number)
             {
+                // Awoids JSON exception when deserializing a numeric value.(In case of API changes)
                 return BillingMapping.Undefined;
             }
             var value = reader.GetString();

--- a/src/Logic/Logic.Models/JsonConverters/BillingMappingConverter.cs
+++ b/src/Logic/Logic.Models/JsonConverters/BillingMappingConverter.cs
@@ -21,7 +21,7 @@ namespace devdeer.CoffeeCupApiAccess.Logic.Models.JsonConverters
         {
             if (reader.TokenType == JsonTokenType.Number)
             {
-                // Awoids JSON exception when deserializing a numeric value.(In case of API changes)
+                // Avoids JSON exception when deserializing a numeric value.(In case of API changes)
                 return BillingMapping.Undefined;
             }
             var value = reader.GetString();

--- a/src/Logic/Logic.Models/JsonConverters/ExpenseCategoryTypeConverter.cs
+++ b/src/Logic/Logic.Models/JsonConverters/ExpenseCategoryTypeConverter.cs
@@ -21,6 +21,7 @@ namespace devdeer.CoffeeCupApiAccess.Logic.Models.JsonConverters
         {
             if (reader.TokenType == JsonTokenType.Number)
             {
+                // Awoids JSON exception when deserializing a numeric value.(In case of API changes)
                 return ExpenseCategoryType.Undefined;
             }
             var value = reader.GetString();

--- a/src/Logic/Logic.Models/JsonConverters/ExpenseCategoryTypeConverter.cs
+++ b/src/Logic/Logic.Models/JsonConverters/ExpenseCategoryTypeConverter.cs
@@ -21,7 +21,7 @@ namespace devdeer.CoffeeCupApiAccess.Logic.Models.JsonConverters
         {
             if (reader.TokenType == JsonTokenType.Number)
             {
-                // Awoids JSON exception when deserializing a numeric value.(In case of API changes)
+                // Avoids JSON exception when deserializing a numeric value.(In case of API changes)
                 return ExpenseCategoryType.Undefined;
             }
             var value = reader.GetString();

--- a/src/Logic/Logic.Models/JsonConverters/ExpenseCategoryTypeConverter.cs
+++ b/src/Logic/Logic.Models/JsonConverters/ExpenseCategoryTypeConverter.cs
@@ -19,6 +19,10 @@ namespace devdeer.CoffeeCupApiAccess.Logic.Models.JsonConverters
             Type typeToConvert,
             JsonSerializerOptions options)
         {
+            if (reader.TokenType == JsonTokenType.Number)
+            {
+                return ExpenseCategoryType.Undefined;
+            }
             var value = reader.GetString();
             return value?.ToUpperInvariant() switch
             {

--- a/src/Logic/Logic.Models/Logic.Models.csproj
+++ b/src/Logic/Logic.Models/Logic.Models.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <Import Project="$(MSBuildThisFileDirectory)../../Base.props"/>
     <PropertyGroup>
-        <Version>4.1.0</Version>
+        <Version>4.1.1</Version>
         <RootNamespace>devdeer.CoffeeCupApiAccess.Logic.Models</RootNamespace>
         <AssemblyName>CoffeeCupApiAccess.Logic.Models</AssemblyName>
         <PackageId>devdeer.CoffeeCupModels</PackageId>

--- a/src/Logic/Logic.Models/Responses/ExpenseCategoryResponse.cs
+++ b/src/Logic/Logic.Models/Responses/ExpenseCategoryResponse.cs
@@ -1,0 +1,24 @@
+namespace devdeer.CoffeeCupApiAccess.Logic.Models.Responses
+{
+    using System;
+    using System.Linq;
+    using System.Text.Json.Serialization;
+
+    using DataModels;
+
+    /// <summary>
+    /// Represents the response of the CoffeeCup API when the expense-categories endpoint is called.
+    /// </summary>
+    public class ExpenseCategoryResponse : BaseResponse
+    {
+        #region properties
+
+        /// <summary>
+        /// The list of colors.
+        /// </summary>
+        [JsonPropertyName("expenseCategories")]
+        public ExpenseCategory[] ExpenseCategories { get; set; } = default!;
+
+        #endregion
+    }
+}

--- a/src/Logic/Logic.Models/Responses/ExpenseResponse.cs
+++ b/src/Logic/Logic.Models/Responses/ExpenseResponse.cs
@@ -1,0 +1,24 @@
+namespace devdeer.CoffeeCupApiAccess.Logic.Models.Responses
+{
+    using System;
+    using System.Linq;
+    using System.Text.Json.Serialization;
+
+    using DataModels;
+
+    /// <summary>
+    /// Represents the response of the CoffeeCup API when the expenses endpoint is called.
+    /// </summary>
+    public class ExpenseResponse : BaseResponse
+    {
+        #region properties
+
+        /// <summary>
+        /// The list of expenses.
+        /// </summary>
+        [JsonPropertyName("expenses")]
+        public Expense[] Expenses { get; set; } = default!;
+
+        #endregion
+    }
+}

--- a/src/Logic/Logic.Models/release-notes.txt
+++ b/src/Logic/Logic.Models/release-notes.txt
@@ -3,4 +3,5 @@
 - User.TimeEntryBackgroundColor is nullable now.
 - Added State for project model.
 - Added expense category and expense models.
+- Small fix for custom JSON converters
 - Nuget updates

--- a/src/Logic/Logic.Models/release-notes.txt
+++ b/src/Logic/Logic.Models/release-notes.txt
@@ -3,5 +3,6 @@
 - User.TimeEntryBackgroundColor is nullable now.
 - Added State for project model.
 - Added expense category and expense models.
+- Added response models for expenses and expense categories.
 - Small fix for custom JSON converters
 - Nuget updates


### PR DESCRIPTION
# Why partial?
This branch will also later bring API methods to `devdeer.CoffeeCupApiAccess`
# Intention
- Adding response models for expenses and expense categories
- Adding unit tests for recently added custom JSON converters
- Bringing small fix to custom JSON converters
# Breaking changes
None