### PR TITLE
Partial PR: Update version to 4.1.2 and fix properties in expense-related models

### DIFF
--- a/src/Logic/Logic.Models/DataModels/Expense.cs
+++ b/src/Logic/Logic.Models/DataModels/Expense.cs
@@ -39,7 +39,7 @@ namespace devdeer.CoffeeCupApiAccess.Logic.Models.DataModels
         /// The quantity of the expense.
         /// </summary>
         [JsonPropertyName("quantity")]
-        public int? Quantity { get; set; }
+        public double? Quantity { get; set; }
 
         /// <summary>
         /// The internal price of the expense.
@@ -75,13 +75,13 @@ namespace devdeer.CoffeeCupApiAccess.Logic.Models.DataModels
         /// The timestamp when the expense was billed.
         /// </summary>
         [JsonPropertyName("billedAt")]
-        public DateTime BilledAt { get; set; }
+        public DateTime? BilledAt { get; set; }
 
         /// <summary>
         /// The day of the expense.
         /// </summary>
         [JsonPropertyName("day")]
-        public DateOnly Day { get; set; }
+        public DateTime Day { get; set; }
 
         /// <summary>
         /// The percentage associated with the expense.

--- a/src/Logic/Logic.Models/DataModels/ExpenseCategory.cs
+++ b/src/Logic/Logic.Models/DataModels/ExpenseCategory.cs
@@ -55,6 +55,9 @@ namespace devdeer.CoffeeCupApiAccess.Logic.Models.DataModels
         [JsonPropertyName("icon")]
         public int Icon { get; set; }
 
+        /// <summary>
+        /// The price per unit of the expense category.
+        /// </summary>
         [JsonPropertyName("pricePerUnit")]
         public double? PricePerUnit { get; set; }
 

--- a/src/Logic/Logic.Models/Logic.Models.csproj
+++ b/src/Logic/Logic.Models/Logic.Models.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <Import Project="$(MSBuildThisFileDirectory)../../Base.props"/>
     <PropertyGroup>
-        <Version>4.1.1</Version>
+        <Version>4.1.2</Version>
         <RootNamespace>devdeer.CoffeeCupApiAccess.Logic.Models</RootNamespace>
         <AssemblyName>CoffeeCupApiAccess.Logic.Models</AssemblyName>
         <PackageId>devdeer.CoffeeCupModels</PackageId>

--- a/src/Logic/Logic.Models/release-notes.txt
+++ b/src/Logic/Logic.Models/release-notes.txt
@@ -5,4 +5,5 @@
 - Added expense category and expense models.
 - Added response models for expenses and expense categories.
 - Small fix for custom JSON converters
+- Expense-related models' properties fixes
 - Nuget updates


### PR DESCRIPTION
## Intention
Bringing fixes to expense model
## Solution
- Patch version bump to `4.1.2`
- Changed properties in `Expense` model:
  - `Quantity` to `double?` from `int?`
  - `BilledAt` to `DateTime?` from `DateTime`
  - `Day` to `DateTime` from `DateOnly`
- Added summaries for `PricePerUnit` property in `ExpenseCategory` model
## Notes
Explicit test for deserializing API responses was conducted to ensure the correct types. That means no further adjustments to the models will be needed