### PR TITLE
Nuget update & small improvements

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,11 +5,11 @@
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="devdeer.CoffeeCupModels" Version="4.1.1" />
+    <PackageVersion Include="devdeer.CoffeeCupModels" Version="4.1.2" />
     <PackageVersion Include="devdeer.Libraries.Utilities" Version="4.0.6" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageVersion Include="NUnit" Version="4.5.0" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="6.1.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageVersion Include="NUnit" Version="4.5.1" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
   </ItemGroup>
 </Project>

--- a/Tests/Tests.Logic.Core/CoffeeCupApiAccessTests.cs
+++ b/Tests/Tests.Logic.Core/CoffeeCupApiAccessTests.cs
@@ -49,6 +49,11 @@
             Assert.That(ApiAccess, Is.Not.Null, "Logic not initialized");
             var result = await ApiAccess.GetExpenseCategoryAsync(Constants.ExpenseCategoryId);
             Assert.That(result, Is.Not.Null);
+            if (result == null)
+            {
+                return;
+            }
+            Assert.That(result.Id, Is.EqualTo(Constants.ExpenseCategoryId));
         }
 
         /// <summary>
@@ -109,6 +114,7 @@
             Assert.That(ApiAccess, Is.Not.Null, "Logic not initialized");
             var result = await ApiAccess.GetProjectExpensesAsync(Constants.ExpensesProjectId);
             Assert.That(result.Length != 0, Is.True);
+            Assert.That(result.All(r => r.ProjectId == Constants.ExpensesProjectId), Is.True);
         }
 
         /// <summary>

--- a/Tests/Tests.Logic.Core/CoffeeCupApiAccessTests.cs
+++ b/Tests/Tests.Logic.Core/CoffeeCupApiAccessTests.cs
@@ -24,7 +24,7 @@
         public async Task GetAbsencyRequests_RetrievesNotNull()
         {
             Assert.That(ApiAccess, Is.Not.Null, "Logic not initialized");
-            var result = await ApiAccess.GetAbsenceRequestsAsync(2024);
+            var result = await ApiAccess.GetAbsenceRequestsAsync(Constants.CurrentYear);
             Assert.That(result, Is.Not.Null);
             Assert.That(result!.Any(), Is.True);
         }
@@ -47,7 +47,7 @@
         public async Task GetExpenseCategoryByIdRequests_RetrievesNotNull()
         {
             Assert.That(ApiAccess, Is.Not.Null, "Logic not initialized");
-            var result = await ApiAccess.GetExpenseCategoryAsync(10);
+            var result = await ApiAccess.GetExpenseCategoryAsync(Constants.ExpenseCategoryId);
             Assert.That(result, Is.Not.Null);
         }
 
@@ -71,7 +71,11 @@
             Assert.That(ApiAccess, Is.Not.Null, "Logic not initialized");
             var result = await ApiAccess.GetVacationBudgetsAsync();
             Assert.That(result, Is.Not.Null);
-            Assert.That(result!.Any(), Is.True);
+            if (result == null)
+            {
+                return;
+            }
+            Assert.That(result.Any(), Is.True);
         }
 
         /// <summary>
@@ -83,13 +87,17 @@
             Assert.That(ApiAccess, Is.Not.Null, "Logic not initialized");
             var filter = new VacationBudgetsFilter
             {
-                UserId = 14766,
-                Date = new DateTime(DateTime.Now.Year, 1, 1)
+                UserId = Constants.VacationBudgetUserId,
+                Date = Constants.BeginningOfYear
             };
             var result = await ApiAccess.GetVacationBudgetsAsync(filter);
             Assert.That(result, Is.Not.Null);
-            Assert.That(result!.Any(), Is.True);
-            Assert.That(result!.All(r => r.UserId == filter.UserId), Is.True);
+            if (result == null)
+            {
+                return;
+            }
+            Assert.That(result.Any(), Is.True);
+            Assert.That(result.All(r => r.UserId == filter.UserId), Is.True);
         }
 
         /// <summary>
@@ -99,7 +107,7 @@
         public async Task GetProjectExpenseRequests_RetrievesNotNull()
         {
             Assert.That(ApiAccess, Is.Not.Null, "Logic not initialized");
-            var result = await ApiAccess.GetProjectExpensesAsync(3402);
+            var result = await ApiAccess.GetProjectExpensesAsync(Constants.ExpensesProjectId);
             Assert.That(result.Length != 0, Is.True);
         }
 
@@ -110,9 +118,7 @@
         public async Task GetTimeEntries_ByDayRange()
         {
             Assert.That(ApiAccess, Is.Not.Null, "Logic not initialized");
-            var minDate = new DateTime(2023, 6, 1);
-            var maxDate = new DateTime(2023, 6, 30);
-            var result = await ApiAccess.GetTimeEntriesByDayRangeAsync(minDate, maxDate);
+            var result = await ApiAccess.GetTimeEntriesByDayRangeAsync(Constants.FromDate, Constants.ToDate);
             Assert.That(result, Is.Not.Null);
             if (result == null)
             {
@@ -121,8 +127,8 @@
             Assert.That(result.Count, Is.GreaterThan(0));
             var minResultDate = result.Min(r => r.Day);
             var maxResultDate = result.Max(r => r.Day);
-            Assert.That(minDate, Is.LessThanOrEqualTo(minResultDate));
-            Assert.That(maxDate, Is.GreaterThanOrEqualTo(maxResultDate));
+            Assert.That(Constants.FromDate, Is.LessThanOrEqualTo(minResultDate));
+            Assert.That(Constants.ToDate, Is.GreaterThanOrEqualTo(maxResultDate));
         }
 
         /// <summary>
@@ -132,23 +138,25 @@
         public async Task GetTimeEntries_Filtered()
         {
             Assert.That(ApiAccess, Is.Not.Null, "Logic not initialized");
-            var minDate = new DateTime(2023, 6, 1);
-            var maxDate = new DateTime(2023, 6, 30);
             var filter = new TimeEntriesFilter
             {
-                From = minDate,
-                To = maxDate,
-                ProjectFilterIds = [15639]
+                From = Constants.FromDate,
+                To = Constants.ToDate,
+                ProjectFilterIds = [Constants.TimeEntriesProjectId]
             };
             var result = await ApiAccess.GetTimeEntriesAsync(filter);
             Assert.That(result, Is.Not.Null);
-            Assert.That(result!.Count(e => e.EndTime < e.StartTime), Is.EqualTo(0));
-            Assert.That(result!.Count, Is.GreaterThan(0));
-            Assert.That(result!.All(r => r.ProjectId == 15639), Is.True);
-            var minResultDate = result!.Min(r => r.Day);
-            var maxResultDate = result!.Max(r => r.Day);
-            Assert.That(minDate, Is.LessThanOrEqualTo(minResultDate));
-            Assert.That(maxDate, Is.GreaterThanOrEqualTo(maxResultDate));
+            if (result == null)
+            {
+                return;
+            }
+            Assert.That(result.Count(e => e.EndTime < e.StartTime), Is.EqualTo(0));
+            Assert.That(result.Count, Is.GreaterThan(0));
+            Assert.That(result.All(r => r.ProjectId == Constants.TimeEntriesProjectId), Is.True);
+            var minResultDate = result.Min(r => r.Day);
+            var maxResultDate = result.Max(r => r.Day);
+            Assert.That(Constants.FromDate, Is.LessThanOrEqualTo(minResultDate));
+            Assert.That(Constants.ToDate, Is.GreaterThanOrEqualTo(maxResultDate));
         }
 
         /// <summary>
@@ -200,7 +208,7 @@
         /// <summary>
         /// Provides easy access to the initialized logic.
         /// </summary>
-        private CoffeeCupAccess ApiAccess { get; set; } = default!;
+        private CoffeeCupAccess ApiAccess { get; set; } = null!;
 
         #endregion
     }

--- a/Tests/Tests.Logic.Core/CoffeeCupApiAccessTests.cs
+++ b/Tests/Tests.Logic.Core/CoffeeCupApiAccessTests.cs
@@ -41,6 +41,17 @@
         }
 
         /// <summary>
+        /// Simple null-check for <see cref="CoffeeCupAccess.GetExpenseCategoryAsync" />.
+        /// </summary>
+        [Test]
+        public async Task GetExpenseCategoryByIdRequests_RetrievesNotNull()
+        {
+            Assert.That(ApiAccess, Is.Not.Null, "Logic not initialized");
+            var result = await ApiAccess.GetExpenseCategoryAsync(10);
+            Assert.That(result, Is.Not.Null);
+        }
+
+        /// <summary>
         /// Simple null-check for <see cref="CoffeeCupAccess.GetExpensesAsync" />.
         /// </summary>
         [Test]

--- a/Tests/Tests.Logic.Core/CoffeeCupApiAccessTests.cs
+++ b/Tests/Tests.Logic.Core/CoffeeCupApiAccessTests.cs
@@ -41,13 +41,13 @@
         }
 
         /// <summary>
-        /// Simple null-check for <see cref="CoffeeCupAccess.GetExpencesAsync" />.
+        /// Simple null-check for <see cref="CoffeeCupAccess.GetExpensesAsync" />.
         /// </summary>
         [Test]
         public async Task GetExpenseRequests_RetrievesNotNull()
         {
             Assert.That(ApiAccess, Is.Not.Null, "Logic not initialized");
-            var result = await ApiAccess.GetExpencesAsync();
+            var result = await ApiAccess.GetExpensesAsync();
             Assert.That(result.Length != 0, Is.True);
         }
 
@@ -82,13 +82,13 @@
         }
 
         /// <summary>
-        /// Simple null-check for <see cref="CoffeeCupAccess.GetProjectExpencesAsync" />.
+        /// Simple null-check for <see cref="CoffeeCupAccess.GetProjectExpensesAsync" />.
         /// </summary>
         [Test]
         public async Task GetProjectExpenseRequests_RetrievesNotNull()
         {
             Assert.That(ApiAccess, Is.Not.Null, "Logic not initialized");
-            var result = await ApiAccess.GetProjectExpencesAsync(3402);
+            var result = await ApiAccess.GetProjectExpensesAsync(3402);
             Assert.That(result.Length != 0, Is.True);
         }
 

--- a/Tests/Tests.Logic.Core/Constants.cs
+++ b/Tests/Tests.Logic.Core/Constants.cs
@@ -1,0 +1,55 @@
+namespace devdeer.CoffeeCupApiAccess.Tests.Logic.Core
+{
+    using System;
+    using System.Linq;
+
+    /// <summary>
+    /// Contains constants used in tests.
+    /// </summary>
+    public static class Constants
+    {
+        #region constants
+
+        /// <summary>
+        /// The id of the expense category used in tests.
+        /// </summary>
+        public const int ExpenseCategoryId = 10;
+
+        /// <summary>
+        /// The id of the project used in tests for retrieving related expenses.
+        /// </summary>
+        public const int ExpensesProjectId = 3402;
+
+        /// <summary>
+        /// The id of the project used in tests for retrieving related time entries.
+        /// </summary>
+        public const int TimeEntriesProjectId = 15639;
+
+        /// <summary>
+        /// The id of the user used in tests for retrieving related vacation budgets.
+        /// </summary>
+        public const int VacationBudgetUserId = 14766;
+
+        /// <summary>
+        /// The current year and the beginning of the year.
+        /// </summary>
+        public static readonly int CurrentYear = DateTime.Now.Year;
+
+        /// <summary>
+        /// The first day of the current year.
+        /// </summary>
+        public static readonly DateTime BeginningOfYear = new(CurrentYear, 1, 1);
+
+        /// <summary>
+        /// The date used for specifying minimal date of a time range.
+        /// </summary>
+        public static readonly DateTime FromDate = new(2023, 6, 1);
+
+        /// <summary>
+        /// The date used for specifying maximal date of a time range.
+        /// </summary>
+        public static readonly DateTime ToDate = new(2023, 6, 30);
+
+        #endregion
+    }
+}

--- a/Tests/Tests.Logic.Models/packages.lock.json
+++ b/Tests/Tests.Logic.Models/packages.lock.json
@@ -4,36 +4,36 @@
     "net10.0": {
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[18.0.1, )",
-        "resolved": "18.0.1",
-        "contentHash": "WNpu6vI2rA0pXY4r7NKxCN16XRWl5uHu6qjuyVLoDo6oYEggIQefrMjkRuibQHm/NslIUNCcKftvoWAN80MSAg==",
+        "requested": "[18.3.0, )",
+        "resolved": "18.3.0",
+        "contentHash": "xW3kXuWRQtgoxJp4J+gdhHSQyK+6Wb/AZDSd7lMvuMRYlZ1tnpkojyfZlWilB5G4dmZ0Y0ZxU/M23TlubndNkw==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.0.1",
-          "Microsoft.TestPlatform.TestHost": "18.0.1"
+          "Microsoft.CodeCoverage": "18.3.0",
+          "Microsoft.TestPlatform.TestHost": "18.3.0"
         }
       },
       "NUnit": {
         "type": "Direct",
-        "requested": "[4.5.0, )",
-        "resolved": "4.5.0",
-        "contentHash": "3AXYqXoll1CnWA+fNqMQemJO5qofh2r75bdrPyJqjCRCcZpwuCAgUnHxG1wKEbrGjtobrWWbwVrDhYcXcxRkjw=="
+        "requested": "[4.5.1, )",
+        "resolved": "4.5.1",
+        "contentHash": "x1sIqU9i0IkxqFayqthzmJs/75jTMbrfNMixj4vtfTi7rRzGbtuY27V+iAhfTY02u5k2qvW3QBGM414OG4q8Lw=="
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.0.1",
-        "contentHash": "O+utSr97NAJowIQT/OVp3Lh9QgW/wALVTP4RG1m2AfFP4IyJmJz0ZBmFJUsRQiAPgq6IRC0t8AAzsiPIsaUDEA=="
+        "resolved": "18.3.0",
+        "contentHash": "23BNy/vziREC20Wwhb50K7+kZe0m07KlLWDQv4qjJ9tt3QjpDpDIqJFrhYHmMEo9xDkuSp55U/8h4bMF7MiB+g=="
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.0.1",
-        "contentHash": "qT/mwMcLF9BieRkzOBPL2qCopl8hQu6A1P7JWAoj/FMu5i9vds/7cjbJ/LLtaiwWevWLAeD5v5wjQJ/l6jvhWQ=="
+        "resolved": "18.3.0",
+        "contentHash": "AEIEX2aWdPO9XbtR96eBaJxmXRD9vaI9uQ1T/JbPEKlTAZwYx0ZrMzKyULMdh/HH9Sg03kXCoN7LszQ90o6nPQ=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.0.1",
-        "contentHash": "uDJKAEjFTaa2wHdWlfo6ektyoh+WD4/Eesrwb4FpBFKsLGehhACVnwwTI4qD3FrIlIEPlxdXg3SyrYRIcO+RRQ==",
+        "resolved": "18.3.0",
+        "contentHash": "twmsoelXnp1uWMU3VGip9f0Jr1mZ0PZqgJdF35CIrdYgYrkHIJMV1m8uKyhcdjLdsQDESHAgkR7KhS9i1qpJag==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.0.1",
+          "Microsoft.TestPlatform.ObjectModel": "18.3.0",
           "Newtonsoft.Json": "13.0.3"
         }
       },

--- a/src/Logic/Logic.Core/CoffeeCupAccess.cs
+++ b/src/Logic/Logic.Core/CoffeeCupAccess.cs
@@ -138,21 +138,6 @@
         }
 
         /// <summary>
-        /// Retrieves the list of expenses from the CoffeeCup API.
-        /// </summary>
-        /// <returns>The list of expenses.</returns>
-        public async ValueTask<Expense[]> GetExpencesAsync()
-        {
-            var apiResult = await GetCoffeeCupApiResultAsync<ExpenseResponse>("expenses");
-            if (apiResult == null)
-            {
-                return [];
-            }
-            return apiResult.Expenses.OrderBy(expense => expense.CreatedAt)
-                .ToArray();
-        }
-
-        /// <summary>
         /// Retrieves the list of expense categories from the CoffeeCup API.
         /// </summary>
         /// <returns>The list of expense categories.</returns>
@@ -164,6 +149,21 @@
                 return [];
             }
             return apiResult.ExpenseCategories.OrderBy(category => category.CreatedAt)
+                .ToArray();
+        }
+
+        /// <summary>
+        /// Retrieves the list of expenses from the CoffeeCup API.
+        /// </summary>
+        /// <returns>The list of expenses.</returns>
+        public async ValueTask<Expense[]> GetExpensesAsync()
+        {
+            var apiResult = await GetCoffeeCupApiResultAsync<ExpenseResponse>("expenses");
+            if (apiResult == null)
+            {
+                return [];
+            }
+            return apiResult.Expenses.OrderBy(expense => expense.CreatedAt)
                 .ToArray();
         }
 
@@ -184,7 +184,7 @@
         /// </summary>
         /// <param name="projectId">The unique id of the project in CoffeeCup.</param>
         /// <returns>The list of expenses.</returns>
-        public async ValueTask<Expense[]> GetProjectExpencesAsync(int projectId)
+        public async ValueTask<Expense[]> GetProjectExpensesAsync(int projectId)
         {
             var apiResult = await GetCoffeeCupApiResultAsync<ExpenseResponse>("expenses");
             if (apiResult == null)

--- a/src/Logic/Logic.Core/CoffeeCupAccess.cs
+++ b/src/Logic/Logic.Core/CoffeeCupAccess.cs
@@ -153,6 +153,17 @@
         }
 
         /// <summary>
+        /// Retrieves an expense category by ID from the CoffeeCup API.
+        /// </summary>
+        /// <param name="categoryId">The unique id of the expense category in CoffeeCup.</param>
+        /// <returns>Expense category or <c>null</c> if not found.</returns>
+        public async ValueTask<ExpenseCategory?> GetExpenseCategoryAsync(int categoryId)
+        {
+            var apiResult = await GetCoffeeCupApiResultAsync<ExpenseCategoryResponse>("expensecategories");
+            return apiResult?.ExpenseCategories.FirstOrDefault(category => category.Id == categoryId);
+        }
+
+        /// <summary>
         /// Retrieves the list of expenses from the CoffeeCup API.
         /// </summary>
         /// <returns>The list of expenses.</returns>

--- a/src/Logic/Logic.Core/Logic.Core.csproj
+++ b/src/Logic/Logic.Core/Logic.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <Import Project="$(MSBuildThisFileDirectory)../../Base.props"/>
     <PropertyGroup>
-        <Version>3.2.0</Version>
+        <Version>3.2.1</Version>
         <RootNamespace>devdeer.CoffeeCupApiAccess.Logic.Core</RootNamespace>
         <AssemblyName>CoffeeCupApiAccess.Logic.Core</AssemblyName>
         <PackageId>devdeer.CoffeeCupApiAccess</PackageId>

--- a/src/Logic/Logic.Core/Logic.Core.csproj
+++ b/src/Logic/Logic.Core/Logic.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <Import Project="$(MSBuildThisFileDirectory)../../Base.props"/>
     <PropertyGroup>
-        <Version>3.2.1</Version>
+        <Version>3.3.0</Version>
         <RootNamespace>devdeer.CoffeeCupApiAccess.Logic.Core</RootNamespace>
         <AssemblyName>CoffeeCupApiAccess.Logic.Core</AssemblyName>
         <PackageId>devdeer.CoffeeCupApiAccess</PackageId>

--- a/src/Logic/Logic.Core/packages.lock.json
+++ b/src/Logic/Logic.Core/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "devdeer.CoffeeCupModels": {
         "type": "Direct",
-        "requested": "[4.1.1, )",
-        "resolved": "4.1.1",
-        "contentHash": "tEfvBnsLLweQWtLdynA8Vu1SMhEGjDI9XlYx/zXToiyzcuz2KCO2PGHvRqVn6BD0z2/T9NOSxMK2OYxCX8xUzQ=="
+        "requested": "[4.1.2, )",
+        "resolved": "4.1.2",
+        "contentHash": "dixZvzPpevme+oAjAKUvk+F2jg2YlU7OnHvbC2yBtESpggj7oFI/GzxuX4nCDjx3NgaayRTn0YxYE43GetryEg=="
       },
       "devdeer.Libraries.Utilities": {
         "type": "Direct",
@@ -137,9 +137,9 @@
     "net8.0": {
       "devdeer.CoffeeCupModels": {
         "type": "Direct",
-        "requested": "[4.1.1, )",
-        "resolved": "4.1.1",
-        "contentHash": "tEfvBnsLLweQWtLdynA8Vu1SMhEGjDI9XlYx/zXToiyzcuz2KCO2PGHvRqVn6BD0z2/T9NOSxMK2OYxCX8xUzQ=="
+        "requested": "[4.1.2, )",
+        "resolved": "4.1.2",
+        "contentHash": "dixZvzPpevme+oAjAKUvk+F2jg2YlU7OnHvbC2yBtESpggj7oFI/GzxuX4nCDjx3NgaayRTn0YxYE43GetryEg=="
       },
       "devdeer.Libraries.Utilities": {
         "type": "Direct",
@@ -277,9 +277,9 @@
     "net9.0": {
       "devdeer.CoffeeCupModels": {
         "type": "Direct",
-        "requested": "[4.1.1, )",
-        "resolved": "4.1.1",
-        "contentHash": "tEfvBnsLLweQWtLdynA8Vu1SMhEGjDI9XlYx/zXToiyzcuz2KCO2PGHvRqVn6BD0z2/T9NOSxMK2OYxCX8xUzQ=="
+        "requested": "[4.1.2, )",
+        "resolved": "4.1.2",
+        "contentHash": "dixZvzPpevme+oAjAKUvk+F2jg2YlU7OnHvbC2yBtESpggj7oFI/GzxuX4nCDjx3NgaayRTn0YxYE43GetryEg=="
       },
       "devdeer.Libraries.Utilities": {
         "type": "Direct",

--- a/tests/Tests.Logic.Core/packages.lock.json
+++ b/tests/Tests.Logic.Core/packages.lock.json
@@ -4,28 +4,29 @@
     "net10.0": {
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[18.0.1, )",
-        "resolved": "18.0.1",
-        "contentHash": "WNpu6vI2rA0pXY4r7NKxCN16XRWl5uHu6qjuyVLoDo6oYEggIQefrMjkRuibQHm/NslIUNCcKftvoWAN80MSAg==",
+        "requested": "[18.3.0, )",
+        "resolved": "18.3.0",
+        "contentHash": "xW3kXuWRQtgoxJp4J+gdhHSQyK+6Wb/AZDSd7lMvuMRYlZ1tnpkojyfZlWilB5G4dmZ0Y0ZxU/M23TlubndNkw==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.0.1",
-          "Microsoft.TestPlatform.TestHost": "18.0.1"
+          "Microsoft.CodeCoverage": "18.3.0",
+          "Microsoft.TestPlatform.TestHost": "18.3.0"
         }
       },
       "NUnit": {
         "type": "Direct",
-        "requested": "[4.5.0, )",
-        "resolved": "4.5.0",
-        "contentHash": "3AXYqXoll1CnWA+fNqMQemJO5qofh2r75bdrPyJqjCRCcZpwuCAgUnHxG1wKEbrGjtobrWWbwVrDhYcXcxRkjw=="
+        "requested": "[4.5.1, )",
+        "resolved": "4.5.1",
+        "contentHash": "x1sIqU9i0IkxqFayqthzmJs/75jTMbrfNMixj4vtfTi7rRzGbtuY27V+iAhfTY02u5k2qvW3QBGM414OG4q8Lw=="
       },
       "NUnit3TestAdapter": {
         "type": "Direct",
-        "requested": "[6.1.0, )",
-        "resolved": "6.1.0",
-        "contentHash": "H4zRIkiGyPa7RpApzXwan5vpZzu4ZDIzuKNlHFiDjOt5Irq4Y5j8r1SA7Oeo0yFCUyfiY7Jy2DTl8RnFZwpKNA==",
+        "requested": "[6.2.0, )",
+        "resolved": "6.2.0",
+        "contentHash": "8PMJB8za2u8S0ey/nEtvh9BHjLhv5yzUEMCmA0+VIPLKSeOAZ3TEHWDyAp0+iPQb3jnBH1o8k0PoU2FgzXLRnQ==",
         "dependencies": {
-          "Microsoft.Testing.Extensions.VSTestBridge": "2.0.2",
-          "Microsoft.Testing.Platform.MSBuild": "2.0.2"
+          "Microsoft.Extensions.DependencyModel": "8.0.2",
+          "Microsoft.Testing.Extensions.VSTestBridge": "2.1.0",
+          "Microsoft.Testing.Platform.MSBuild": "2.1.0"
         }
       },
       "Microsoft.ApplicationInsights": {
@@ -35,8 +36,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.0.1",
-        "contentHash": "O+utSr97NAJowIQT/OVp3Lh9QgW/wALVTP4RG1m2AfFP4IyJmJz0ZBmFJUsRQiAPgq6IRC0t8AAzsiPIsaUDEA=="
+        "resolved": "18.3.0",
+        "contentHash": "23BNy/vziREC20Wwhb50K7+kZe0m07KlLWDQv4qjJ9tt3QjpDpDIqJFrhYHmMEo9xDkuSp55U/8h4bMF7MiB+g=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
@@ -76,6 +77,11 @@
         "type": "Transitive",
         "resolved": "10.0.5",
         "contentHash": "iVMtq9eRvzyhx8949EGT0OCYJfXi737SbRVzWXE5GrOgGj5AaZ9eUuxA/BSUfmOMALKn/g8KfFaNQw0eiB3lyA=="
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "8.0.2",
+        "contentHash": "mUBDZZRgZrSyFOsJ2qJJ9fXfqd/kXJwf3AiDoqLD9m6TjY5OO/vLNOb9fb4juC0487eq4hcGN/M2Rh/CKS7QYw=="
       },
       "Microsoft.Extensions.Diagnostics": {
         "type": "Transitive",
@@ -142,62 +148,56 @@
       },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
-        "resolved": "2.0.2",
-        "contentHash": "H580BvHyuADoWzlH9zRk5fqVyGucm6mhph+k40CQc9O4ie+Buxa4Pk9Q92BEClqIICqi25J7fuMII9qFYYgKtw==",
+        "resolved": "2.1.0",
+        "contentHash": "5TwgTx2u7k9Al/xbZ18QXq4Hdy2xewkVTI6K3sk+jY2ykqUkIKNuj7rFu3GOV5KnEUkevhw6eZcyZs77STHJIA==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.23.0",
-          "Microsoft.Testing.Platform": "2.0.2"
+          "Microsoft.Testing.Platform": "2.1.0"
         }
       },
       "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
         "type": "Transitive",
-        "resolved": "2.0.2",
-        "contentHash": "MrHYdPZ1CiyYp5bfjzNSghfVwl/I9osMazcZMAbwZY0BhR32i70YLf4zSXECvU2qt2PvDdrjYpGRgBscFbjDpw==",
+        "resolved": "2.1.0",
+        "contentHash": "D8xmIJYQFJ6D49Rx5/vPrkZZxb338Jkew+eSqZLBfBiWKw4QZKy3i1BOXiLfz0lOmaNErwDz/YWRojCdNl+B9Q==",
         "dependencies": {
-          "Microsoft.Testing.Platform": "2.0.2"
+          "Microsoft.Testing.Platform": "2.1.0"
         }
       },
       "Microsoft.Testing.Extensions.VSTestBridge": {
         "type": "Transitive",
-        "resolved": "2.0.2",
-        "contentHash": "6WSUZyv71NmF1bhFWpNht2bskVWL/5Lcu9qxDUnnboYRiujh9w4swn/cPSbVCSGXwyMq9uKRlI9zZ+ReBO8e+Q==",
+        "resolved": "2.1.0",
+        "contentHash": "bNRIEA2YoGr+Y+7LHdA7i1U80+7BAdf4K4Qh4Kx6eKkoBK/NV7QpoMg+GWPP0/eqAFzuUmUOIPVZ87Oo0Vyxmw==",
         "dependencies": {
-          "Microsoft.TestPlatform.AdapterUtilities": "18.0.1",
           "Microsoft.TestPlatform.ObjectModel": "18.0.1",
-          "Microsoft.Testing.Extensions.Telemetry": "2.0.2",
-          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.0.2",
-          "Microsoft.Testing.Platform": "2.0.2"
+          "Microsoft.Testing.Extensions.Telemetry": "2.1.0",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.1.0",
+          "Microsoft.Testing.Platform": "2.1.0"
         }
       },
       "Microsoft.Testing.Platform": {
         "type": "Transitive",
-        "resolved": "2.0.2",
-        "contentHash": "43NCOTEENtdc9fmlzX9KHQR14AZEYek5r4jOJlWPhTyV1+aYAQYl4x773nYXU5TKxV6+rMuniJ7wcj9C9qrP1A=="
+        "resolved": "2.1.0",
+        "contentHash": "aHkjNTGIA+Zbdw6RJgSFrbDrCjO0CgqpElqYcvkRSeUhBv2bKarnvU3ep786U7UqrPlArT/B7VmImRibJD0Zrg=="
       },
       "Microsoft.Testing.Platform.MSBuild": {
         "type": "Transitive",
-        "resolved": "2.0.2",
-        "contentHash": "2zKkQKaUoaKgb/3AekboWOdLMh4upCo1nLWQnjGzp8r9YjiNOZRrzTsJQ3A4U03AcbH0evlIvFDKYSUqmTVuug==",
+        "resolved": "2.1.0",
+        "contentHash": "UpfPebXQtHGrWz21+YLHmJSm+5zsuPE9U9pfdCtoB+67g75fDmWlNgpkH2ZmdVhSwkjNIed9Icg8Iu63z2ei5Q==",
         "dependencies": {
-          "Microsoft.Testing.Platform": "2.0.2"
+          "Microsoft.Testing.Platform": "2.1.0"
         }
-      },
-      "Microsoft.TestPlatform.AdapterUtilities": {
-        "type": "Transitive",
-        "resolved": "18.0.1",
-        "contentHash": "gXIugDKnACB8p93+9dFnMdE7vvs0ZrjjDltdGC4VylbKK7gPegWYASGjryVkIDvFr56Ulx4UDIKsB71qYHJBWg=="
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.0.1",
-        "contentHash": "qT/mwMcLF9BieRkzOBPL2qCopl8hQu6A1P7JWAoj/FMu5i9vds/7cjbJ/LLtaiwWevWLAeD5v5wjQJ/l6jvhWQ=="
+        "resolved": "18.3.0",
+        "contentHash": "AEIEX2aWdPO9XbtR96eBaJxmXRD9vaI9uQ1T/JbPEKlTAZwYx0ZrMzKyULMdh/HH9Sg03kXCoN7LszQ90o6nPQ=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.0.1",
-        "contentHash": "uDJKAEjFTaa2wHdWlfo6ektyoh+WD4/Eesrwb4FpBFKsLGehhACVnwwTI4qD3FrIlIEPlxdXg3SyrYRIcO+RRQ==",
+        "resolved": "18.3.0",
+        "contentHash": "twmsoelXnp1uWMU3VGip9f0Jr1mZ0PZqgJdF35CIrdYgYrkHIJMV1m8uKyhcdjLdsQDESHAgkR7KhS9i1qpJag==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.0.1",
+          "Microsoft.TestPlatform.ObjectModel": "18.3.0",
           "Newtonsoft.Json": "13.0.3"
         }
       },
@@ -210,7 +210,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Http": "[10.0.5, )",
-          "devdeer.CoffeeCupModels": "[4.1.1, )",
+          "devdeer.CoffeeCupModels": "[4.1.2, )",
           "devdeer.Libraries.Utilities": "[4.0.6, )"
         }
       },


### PR DESCRIPTION
## Intention
- NuGet packages update
- Small fixes
- Tests improvements

## Highligts
- Minor version bump on `Logic.Core` to `3.3.0`
- Updated CoffeCup models package to `4.1.2` and other NuGet updates
- Added new method for retrieving expense category by its ID and corresponding Test
- Introduced `Constants` class in `Tests.Logic` to avoid 'magic strings'

## Breaking changes
- Method renaming: `GetExpencesAsync` -> `GetExpensesAsync`